### PR TITLE
Fix for sync and unloaded translations

### DIFF
--- a/lib/tolk/sync.rb
+++ b/lib/tolk/sync.rb
@@ -10,7 +10,7 @@ module Tolk
       end
 
       def load_translations
-        I18n.available_locales # force load
+        I18n.backend.send :init_translations unless I18n.backend.initialized? # force load
         translations = flat_hash(I18n.backend.send(:translations)[primary_locale.name.to_sym])
         filter_out_i18n_keys(translations.merge(read_primary_locale_file))
       end


### PR DESCRIPTION
Fix for unloaded translations when running rake tolk:sync:

```
undefined method `each' for nil:NilClass
/Users/joost/.rvm/gems/ruby-1.9.3-p194/gems/tolk-1.3.0/lib/tolk/sync.rb:24:in `flat_hash'
/Users/joost/.rvm/gems/ruby-1.9.3-p194/gems/tolk-1.3.0/lib/tolk/sync.rb:14:in `load_translations'
/Users/joost/.rvm/gems/ruby-1.9.3-p194/gems/tolk-1.3.0/lib/tolk/sync.rb:9:in `sync!'
```
