### PR TITLE
Apply .html_safe to returned value from format_i18n_value

### DIFF
--- a/app/helpers/tolk/application_helper.rb
+++ b/app/helpers/tolk/application_helper.rb
@@ -1,7 +1,7 @@
 module Tolk
   module ApplicationHelper
     def format_i18n_value(value)
-      h(yaml_value(value)).gsub(/\n/, '<br />')
+      h(yaml_value(value)).gsub(/\n/, '<br />').html_safe
     end
 
     def format_i18n_text_area_value(value)

--- a/app/views/tolk/locales/show.html.erb
+++ b/app/views/tolk/locales/show.html.erb
@@ -33,7 +33,7 @@
               <% if params[:q].present? -%>
                 <%= highlight(format_i18n_value(phrase.translations.primary.text), params[:q]) -%>
               <% else -%>
-                <%= format_i18n_value(phrase.translations.primary.text).html_safe -%>
+                <%= format_i18n_value(phrase.translations.primary.text) -%>
               <% end -%>
               <span class="key" title="<%= phrase.key %>"><%= truncate(phrase.key, :length => 100) %></span>
             </td>


### PR DESCRIPTION
This fix addresses an issue where viewing the format_i18n_value helper is returning a non-html_safe value, causing the view to escape the &lt;br /&gt; tags added by the helper.  The bug manifests itself when viewing non-hilighted results.
