### PR TITLE
Add visual representation of carriage returns.

### DIFF
--- a/app/assets/stylesheets/tolk/screen.css
+++ b/app/assets/stylesheets/tolk/screen.css
@@ -288,6 +288,11 @@ table.translations .highlight {
   background-color: yellow;
 }
 
+table.translations .phrase .carriage_return {
+	color: #2fadcf;
+	font-weight: bold;
+}
+
 /*-------------------------------------------------
 Pagination
 -------------------------------------------------*/

--- a/app/helpers/tolk/application_helper.rb
+++ b/app/helpers/tolk/application_helper.rb
@@ -1,7 +1,7 @@
 module Tolk
   module ApplicationHelper
     def format_i18n_value(value)
-      h(yaml_value(value)).gsub(/\n/, '<br />').html_safe
+      h(yaml_value(value)).gsub(/\n/, '<span class="carriage_return">&crarr;</span><br />').html_safe
     end
 
     def format_i18n_text_area_value(value)


### PR DESCRIPTION
Add a visual representation of an explicit carriage return in a translation to address the ambiguity this and that of a soft-wrap applied due to the size of the browser window.
