### PR TITLE
Locale #find_by_name! Case Sensitivity

### DIFF
--- a/app/controllers/tolk/locales_controller.rb
+++ b/app/controllers/tolk/locales_controller.rb
@@ -40,7 +40,7 @@ module Tolk
     private
 
     def find_locale
-      @locale = Tolk::Locale.find_by_name!(params[:id])
+      @locale = Tolk::Locale.where('UPPER(name) = UPPER(?)', params[:id]).first!
     end
   end
 end

--- a/app/controllers/tolk/searches_controller.rb
+++ b/app/controllers/tolk/searches_controller.rb
@@ -9,7 +9,7 @@ module Tolk
     private
 
     def find_locale
-      @locale = Tolk::Locale.find_by_name!(params[:locale])
+      @locale = Tolk::Locale.where('UPPER(name) = UPPER(?)', params[:locale]).first!
     end
   end
 end


### PR DESCRIPTION
I discovered an issue with browsing to the Simplified Chinese locale `/locales/zh-cn` where it did not find the locale by name in the DB. This is of course due to case sensitivity as the locale is actually `zh-CN`.

Attached is a pull request that finds the locale ignoring the case.

Cheers,
Hugh
