### PR TITLE
fixed pluralization handling

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,0 +1,1 @@
+rvm --create ruby-1.9.3-p194@tolk

--- a/app/models/tolk/locale.rb
+++ b/app/models/tolk/locale.rb
@@ -64,7 +64,8 @@ module Tolk
         self.special_prefixes.include?(prefix) || self.special_keys.include?(key)
       end
 
-      PLURALIZATION_KEYS = ['none', 'one', 'two', 'few', 'many', 'other']
+      # http://cldr.unicode.org/index/cldr-spec/plural-rules - TODO: usage of 'none' isn't standard-conform
+      PLURALIZATION_KEYS = ['none', 'zero', 'one', 'two', 'few', 'many', 'other']
       def pluralization_data?(data)
         keys = data.keys.map(&:to_s)
         keys.all? {|k| PLURALIZATION_KEYS.include?(k) }

--- a/lib/tolk/import.rb
+++ b/lib/tolk/import.rb
@@ -8,13 +8,13 @@ module Tolk
 
       def import_secondary_locales
         locales = Dir.entries(self.locales_config_path)
-        
-        locale_block_filter = Proc.new { 
+
+        locale_block_filter = Proc.new {
           |l| ['.', '..'].include?(l) ||
             !l.ends_with?('.yml') ||
             l.match(/(.*\.){2,}/) # reject files of type xxx.en.yml
         }
-        locales = locales.reject(&locale_block_filter).map {|x| x.split('.').first } 
+        locales = locales.reject(&locale_block_filter).map {|x| x.split('.').first }
         locales = locales - [Tolk::Locale.primary_locale.name]
         locales.each {|l| import_locale(l) }
       end
@@ -32,9 +32,13 @@ module Tolk
 
           if phrase
             translation = locale.translations.new(:text => value, :phrase => phrase)
-            count = count + 1 if translation.save
+            if translation.save
+              count = count + 1
+            elsif translation.errors[:variables].present?
+              puts "[WARN] Key '#{key}' from '#{locale_name}.yml' could not be saved: #{translation.errors[:variables].first}"
+            end
           else
-            puts "[ERROR] Key '#{key}' was found in #{locale_name}.yml but #{Tolk::Locale.primary_language_name} translation is missing"
+            puts "[ERROR] Key '#{key}' was found in '#{locale_name}.yml' but #{Tolk::Locale.primary_language_name} translation is missing"
           end
         end
 

--- a/test/locales/formats/en.yml
+++ b/test/locales/formats/en.yml
@@ -9,7 +9,13 @@ en:
   number_array: [1, 2, 3]
   string_array: ['sun', 'moon']
   pluralization:
-    other: Hello
+    none: none
+    zero: zero
+    one: one
+    two: two
+    few: few
+    many: many
+    other: other
   not_pluralization:
     other: World
     lifo: fifo

--- a/test/unit/format_test.rb
+++ b/test/unit/format_test.rb
@@ -27,11 +27,19 @@ class FormatTest < ActiveSupport::TestCase
     assert_equal ['sun', 'moon'], @en.get('string_array')
   end
 
-  def test_pluaralization
-    result = {'other' => 'Hello'}
+  def test_pluralization
+    result = {
+      "none"  => "none",
+      "zero"  => "zero",
+      "one"   => "one",
+      "two"   => "two",
+      "few"   => "few",
+      "many"  => "many",
+      "other" => "other"
+    }
     assert_equal result, @en.get('pluralization')
 
-    assert ! @en.get('not_pluralization')
+    assert_nil @en.get('not_pluralization')
     assert_equal 'World', @en.get('not_pluralization.other')
     assert_equal 'fifo', @en.get('not_pluralization.lifo')
   end

--- a/test/unit/import_test.rb
+++ b/test/unit/import_test.rb
@@ -19,10 +19,7 @@ class ImportTest < ActiveSupport::TestCase
   test "skips gem translations files (xxx.en.yml)" do
     Tolk::Locale.sync!
     Tolk::Locale.import_secondary_locales
-    
 
     assert_equal 0, Tolk::Phrase.where(key: 'gem_hello_world').count
-    
   end
-  
 end

--- a/test/unit/translation_test.rb
+++ b/test/unit/translation_test.rb
@@ -9,36 +9,77 @@ class TranslationTest < ActiveSupport::TestCase
   end
 
   test "translation is inavlid when a duplicate exists" do
-    translation = Tolk::Translation.new :phrase => tolk_translations(:hello_world_da).phrase, :locale => tolk_translations(:hello_world_da).locale
+    translation = Tolk::Translation.new(:phrase => tolk_translations(:hello_world_da).phrase, :locale => tolk_translations(:hello_world_da).locale)
     translation.text = "Revised Hello World"
-    assert translation.invalid?
-    assert translation.errors[:phrase_id]
+    assert(translation.invalid?)
+    assert(translation.errors[:phrase_id])
   end
-  
+
   test "translation is not changed when text is assigned an equal value in numberic form" do
     translation = tolk_translations(:human_format_precision_en)
-    assert_equal "1", translation.text
+    assert_equal("1", translation.text)
     translation.text = "1"
-    assert_equal false, translation.changed?
+    assert_equal(false, translation.changed?)
     translation.text = 1
-    assert_equal false, translation.changed?
+    assert_equal(false, translation.changed?)
   end
 
   test "translation with string value" do
-    assert_equal "Hello World", tolk_translations(:hello_world_en).value
+    assert_equal("Hello World", tolk_translations(:hello_world_en).value)
   end
 
   test "translation with string value with variables" do
     text = "{{attribute}} {{message}}"
-    assert_equal text, Tolk::Translation.new(:text => text).value
+    assert_equal(text, Tolk::Translation.new(:text => text).value)
   end
 
   test "translation with numeric value" do
-    assert_equal 1, tolk_translations(:human_format_precision_en).value
+    assert_equal(1, tolk_translations(:human_format_precision_en).value)
   end
-  
+
   test "translation with hash value" do
     hash = {:foo => "bar"}
-    assert_equal hash, Tolk::Translation.new(:text => hash).value
+    assert_equal(hash, Tolk::Translation.new(:text => hash).value)
+  end
+
+  test "pluralization translation special variable 'count' not a variable" do
+    text = {
+      'zero' => "{{message}}",
+      'many' => "{{message}} {{count}}",
+      'other' => "{{message}} {{count}}"
+    }
+    assert_equal(Set['message'], Tolk::Translation.detect_variables(text))
+  end
+
+  test "validation for variables (mismatch)" do
+    primary_text = {
+      'zero' => "{{message}}",
+      'many' => "{{message}} {{count}}",
+    }
+    text = {
+      'zero' => "{{message}}",
+      'many' => "{{foo}}",
+    }
+
+    Tolk::Translation.new(:text => text).tap do |t|
+      t.stubs(:primary_translation).returns(Tolk::Translation.new(:text => primary_text))
+      t.valid?
+      assert_equal ["The translation should contain the substitutions of the primary translation: (message), found (message, foo)."], t.errors[:variables]
+    end
+  end
+
+  test "validation for variables (no variables in primary)" do
+    primary_text = {
+      'foo' => "nada"
+    }
+    text = {
+      'foo' => "{{foo}} nada"
+    }
+
+    Tolk::Translation.new(:text => text).tap do |t|
+      t.stubs(:primary_translation).returns(Tolk::Translation.new(:text => primary_text))
+      t.valid?
+      assert_equal ["The primary translation does not contain substitutions, so this should neither."], t.errors[:variables]
+    end
   end
 end


### PR DESCRIPTION
- added missing 'zero' key to pluralization recognition
- removed 'count' variable from translation validations for pluralization data
- added warning output to import task mentioning pluralization variable problems
