### PR TITLE
Namespace locale parameter in search form

### DIFF
--- a/app/controllers/tolk/searches_controller.rb
+++ b/app/controllers/tolk/searches_controller.rb
@@ -9,7 +9,7 @@ module Tolk
     private
 
     def find_locale
-      @locale = Tolk::Locale.where('UPPER(name) = UPPER(?)', params[:locale]).first!
+      @locale = Tolk::Locale.where('UPPER(name) = UPPER(?)', params[:tolk_locale]).first!
     end
   end
 end

--- a/app/views/tolk/searches/_form.html.erb
+++ b/app/views/tolk/searches/_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_tag tolk.search_path, :method => :get do %>
-  <%= hidden_field_tag :locale, locale.name %>
+  <%= hidden_field_tag :tolk_locale, locale.name %>
   Search for
   <%= scope_selector_for(@locale) %>
   phrase:


### PR DESCRIPTION
Renamed `params[:locale]` to `params[:tolk_locale]`in the searches controller / search form.

This prevents an issue when used inside an app with its own `locale` parameter
