### PR TITLE
Bypass validations on Tolk::Sync#sync_phrases

### DIFF
--- a/app/models/tolk/translation.rb
+++ b/app/models/tolk/translation.rb
@@ -17,7 +17,6 @@ module Tolk
 
     attr_accessible :phrase_id, :locale_id, :text, :primary_updated, :previous_text, :locale, :phrase
 
-    attr_accessor :force_set_primary_update
     before_save :set_primary_updated
 
     before_save :set_previous_text
@@ -138,7 +137,7 @@ module Tolk
     end
 
     def set_primary_updated
-      self.primary_updated = self.force_set_primary_update ? true : false
+      self.primary_updated = false
       true
     end
 

--- a/test/unit/format_test.rb
+++ b/test/unit/format_test.rb
@@ -124,8 +124,7 @@ class FormatTest < ActiveSupport::TestCase
     @spanish.save!
 
     spanish_string = @spanish.translations.first
-    spanish_string.force_set_primary_update = true
-    spanish_string.save!
+    spanish_string.update_column(:primary_updated, true)
     assert spanish_string.primary_updated?
 
     @spanish.reload


### PR DESCRIPTION
When updating the primary_updated flag on secondary phrases for which
the primary phrase has been updated, use a direct-to-DB call to avoid
invoking possibly heavy ActiveRecord validations or triggering an
exeption when the variables used in the phrase change. (fixes #28)
