### PR TITLE
Fixed Portuguese Brazilian locale code

### DIFF
--- a/lib/tolk/config.rb
+++ b/lib/tolk/config.rb
@@ -10,10 +10,10 @@ module Tolk
 
       # Dump locale path by default the locales folder (config/locales)
       attr_accessor :dump_path
-      
+
       def reset
         @dump_path = Proc.new { "#{Rails.application.root}/config/locales" }
-        
+
         @mapping = {
           'ar'    => 'Arabic',
           'bs'    => 'Bosnian',
@@ -44,7 +44,7 @@ module Tolk
           'nl'    => 'Dutch',
           'no'    => 'Norwegian',
           'pl'    => 'Polish',
-          'pt-br' => 'Portuguese (Brazilian)',
+          'pt-BR' => 'Portuguese (Brazilian)',
           'pt-PT' => 'Portuguese (Portugal)',
           'ro'    => 'Romanian',
           'ru'    => 'Russian',


### PR DESCRIPTION
The next lines ensure the compatibility.

https://github.com/tolk/tolk/blob/master/app/controllers/tolk/locales_controller.rb#L48-L50
