### PR TITLE
Strip text for translations

### DIFF
--- a/app/models/tolk/translation.rb
+++ b/app/models/tolk/translation.rb
@@ -61,6 +61,7 @@ module Tolk
         end
         super unless value == text
       else
+        value = value.strip if value.is_a?(String)
         super unless value.to_s == text
       end
     end

--- a/test/unit/translation_test.rb
+++ b/test/unit/translation_test.rb
@@ -28,6 +28,11 @@ class TranslationTest < ActiveSupport::TestCase
     assert_equal("Hello World", tolk_translations(:hello_world_en).value)
   end
 
+  test "translation with string value with leading and trailing whitespace" do
+    text = "\t          Hello World   \r\n"
+    assert_equal(text.strip, Tolk::Translation.new(:text => text).value)
+  end
+
   test "translation with string value with variables" do
     text = "{{attribute}} {{message}}"
     assert_equal(text, Tolk::Translation.new(:text => text).value)


### PR DESCRIPTION
Avoid add \n,\t, blanc spaces in translations that can break the website design.
