### PR TITLE
Bug fixes and improvements of translation UI

### DIFF
--- a/app/assets/javascripts/tolk/actions.js
+++ b/app/assets/javascripts/tolk/actions.js
@@ -5,23 +5,18 @@ $(function () {
     e.preventDefault();
 
     var row = $(this).parents("tr")
-      , original = row.find(".phrase .original").text();
+      , original_text = row.find(".original textarea").val();
 
-    row.find(".translation textarea").addClass("dirty").val(original.trim());
-
-    // Bind the dirty callback after copy
-    window.onbeforeunload = confirm;
+    row.find(".translation textarea").val(original_text.trim()).trigger("change");
   });
 
   // avoid lose data
-  $(".translations textarea").bind("blur", function () {
-    if ($(this).is(".dirty")) {
-      window.onbeforeunload = confirm;
-    }
+  $(".translations textarea").bind("keydown", function () {
+    window.onbeforeunload = confirm;
   });
 
-  $(".translations textarea").bind("keydown", function () {
-    $(this).addClass("dirty");
+  $(".translations textarea").bind("change", function () {
+    window.onbeforeunload = confirm;
   });
 
   $("input.save, input.apply").click(function () {

--- a/app/assets/javascripts/tolk/interpolations.js
+++ b/app/assets/javascripts/tolk/interpolations.js
@@ -1,37 +1,21 @@
 $(function () {
+
   var interpolation = new RegExp("%{\\w+}", "g");
+  
+  $(".translations textarea").bind("change", function () {
+      var row = $(this).parents("tr")
+        , original_text = row.find(".original textarea").val()
+        , translated_text = $(this).val()
+        , original_interpolations = original_text.match(interpolation) || []
+        , translated_interpolations = translated_text.match(interpolation) || []
+        , not_match;
 
-  $(".phrase .value").each(function () {
-    var text = $('<div/>').text($(this).text()).html()
-      , token_text;
+      not_match = translated_text.length > 0 &&
+                  ($(original_interpolations).not(translated_interpolations).length !== 0 ||
+                   $(translated_interpolations).not(original_interpolations).length !== 0);
 
-    token_text = text.replace(interpolation, function (match) {
-      return '<span class="interpolation"  title="Don\'t translate this word">' + match + '</span>';
+      row.find(".actions .warning").toggle(not_match);
+
     });
-
-    $(this).html(token_text);
-  });
-
-  $(".translations textarea").bind("focus", function () {
-    $(this).parents("tr").toggleClass('active');
-  });
-
-  $(".translations textarea").bind("blur", function () {
-    $(this).parents("tr").toggleClass('active');
-
-    var row = $(this).parents("tr")
-      , original_text = row.find(".phrase .original").text()
-      , translated_text = $(this).val()
-      , original_interpolations = original_text.match(interpolation) || []
-      , translated_interpolations = translated_text.match(interpolation) || []
-      , not_match;
-
-    not_match = translated_text.length > 0 &&
-                ($(original_interpolations).not(translated_interpolations).length !== 0 ||
-                 $(translated_interpolations).not(original_interpolations).length !== 0);
-
-    row.find(".actions .warning").toggle(not_match);
-
-  });
 
 });

--- a/app/assets/javascripts/tolk/layout.js
+++ b/app/assets/javascripts/tolk/layout.js
@@ -1,9 +1,17 @@
-
 $(function () {
 
   // Fit text area height
-  $('td textarea').each(function () {
+  $('.translations textarea').each(function () {
     $(this).css({ height: $(this).parent('td').css('height')});
+  });
+
+  // Mark active textarea
+  $(".translations textarea").bind("focus", function () {
+    $(this).parents("tr").toggleClass('active');
+  });
+
+  $(".translations textarea").bind("blur", function () {
+    $(this).parents("tr").toggleClass('active');
   });
 
 });

--- a/app/assets/stylesheets/tolk/screen.css
+++ b/app/assets/stylesheets/tolk/screen.css
@@ -241,7 +241,7 @@ span.notice {
   display: inline-block;
 }
 
-div.original {
+div.previous {
   color: #999;
   margin: 5px 0;
   padding: 1px 8px 4px;
@@ -252,7 +252,7 @@ div.updated {
   padding: 1px 8px 4px;
 }
 
-table.translations div.original span.key {
+table.translations div.previous span.key {
   margin: 0 0 -2px;
   padding: 0;
 }
@@ -332,7 +332,7 @@ table.translations td.actions .warning {
   color: orange;
   padding: 2px 4px;
   display: none;
-  cursor: default;
+  cursor: help;
 }
 
 table.translations tr.active td {
@@ -343,20 +343,21 @@ table.translations .highlight {
   background-color: yellow;
 }
 
-table.translations .original {
+table.translations .original textarea {
   display: none;
 }
 
-table.translations .interpolation {
+table.translations .original .interpolation, 
+table.translations .original .carriage_return,
+table.translations .original .boolean  {
   color: #2fadcf;
-  font-family: Courier;
+  font-family: Courier, monospace;
   font-weight: bold;
-  cursor: pointer;
+  cursor: help;
 }
 
-table.translations .phrase .carriage_return, table.translations .phrase .boolean {
-  color: #2fadcf;
-  font-weight: bold;
+table.translations .original .carriage_return:before {
+  content: "¶";
 }
 
 /*-------------------------------------------------

--- a/app/helpers/tolk/application_helper.rb
+++ b/app/helpers/tolk/application_helper.rb
@@ -1,7 +1,17 @@
 module Tolk
   module ApplicationHelper
     def format_i18n_value(value)
-      h(yaml_value(value)).gsub(/\n/, '<span class="carriage_return">&crarr;</span><br />').html_safe
+      value = h(yaml_value(value))
+      value = highlight_linebreaks(value)
+      value = highligh_interpolations(value)
+    end
+
+    def highlight_linebreaks(value)
+      value.gsub(/\n/, '<span class="carriage_return" title="Line break"><br /></span>').html_safe
+    end
+
+    def highligh_interpolations(value)
+      value.gsub(/%{\w+}/, '<span class="interpolation" title="Leave this word untranslated">\0</span>').html_safe
     end
 
     def format_i18n_text_area_value(value)

--- a/app/views/tolk/locales/all.html.erb
+++ b/app/views/tolk/locales/all.html.erb
@@ -30,25 +30,21 @@
               <a class="copy" href="#" tabindex="-1" title="Copy original translation">&larr;</a><br>
               <span class="warning" title="Interpolation keys don't match">⚠</span>
             </td>
-            <td class="phrase">
-
+            <td class="original">
+              <%= text_area_tag :"translations[][original_text]", format_i18n_text_area_value(phrase.translations.primary.text), :disabled => true %>
+              
               <% if action_name == 'updated' %>
                 <div class="updated">
                   <span class="key">Updated</span>
                   <%= format_i18n_value(phrase.translations.primary.text) -%>
                   <%= boolean_warning if phrase.translations.primary.boolean? -%>
                 </div>
-                <div class="original">
-                  <span class="key">Original</span>
+                <div class="previous">
+                  <span class="key">Previous</span>
                   <%= format_i18n_value(phrase.translations.primary.previous_text) -%>
                 </div>
               <% else %>
-                <div class="original">
-                  <%= format_i18n_value(phrase.translations.primary.text) -%>
-                </div>
-                <div class="value">
-                  <%= format_i18n_value(phrase.translations.primary.text) -%>
-                </div>
+                <%= format_i18n_value(phrase.translations.primary.text) -%>
                 <%= boolean_warning if phrase.translations.primary.boolean? -%>
               <% end %>
 

--- a/app/views/tolk/locales/show.html.erb
+++ b/app/views/tolk/locales/show.html.erb
@@ -34,18 +34,16 @@
               <a class="copy" href="#" tabindex="-1" title="Copy original translation">&larr;</a><br>
               <span class="warning" title="Interpolation keys don't match">⚠</span>
             </td>
-            <td class="phrase">
-              <div class="original">
+            <td class="original">
+              <%= text_area_tag :"translations[][original_text]", format_i18n_text_area_value(phrase.translations.primary.text), :disabled => true %>
+
+              <% if params[:q].present? -%>
+                <%= highlight(format_i18n_value(phrase.translations.primary.text), params[:q]) -%>
+              <% else -%>
                 <%= format_i18n_value(phrase.translations.primary.text) -%>
-              </div>
-              <div class="value">
-                <% if params[:q].present? -%>
-                  <%= highlight(format_i18n_value(phrase.translations.primary.text), params[:q]) -%>
-                <% else -%>
-                  <%= format_i18n_value(phrase.translations.primary.text) -%>
-                <% end -%>
-                <%= boolean_warning if phrase.translations.primary.boolean? -%>
-              </div>
+              <% end -%>
+              <%= boolean_warning if phrase.translations.primary.boolean? -%>
+
               <span class="key" title="<%= phrase.key %>"><%= truncate(phrase.key, :length => 100) %></span>
             </td>
           </tr>

--- a/app/views/tolk/searches/show.html.erb
+++ b/app/views/tolk/searches/show.html.erb
@@ -31,21 +31,19 @@
                 <a class="copy" href="#" tabindex="-1" title="Copy original translation">&larr;</a><br>
                 <span class="warning" title="Interpolation keys don't match">⚠</span>
               </td>
-              <td class="phrase">
-                <div class="original">
+              <td class="original">
+                <%= text_area_tag :"translations[][original_text]", format_i18n_text_area_value(phrase.translations.primary.text), :disabled => true %>
+
+                <% if params[:q].present? -%>
+                  <%= highlight(format_i18n_value(phrase.translations.primary.text), params[:q]) -%>
+                <% else -%>
                   <%= format_i18n_value(phrase.translations.primary.text) -%>
-                </div>
-                <div class="value">
-                  <% if params[:q].present? -%>
-                    <%= highlight(format_i18n_value(phrase.translations.primary.text), params[:q]) -%>
-                  <% else -%>
-                    <%= format_i18n_value(phrase.translations.primary.text) -%>
-                  <% end -%>
-                  <%= boolean_warning if phrase.translations.primary.boolean? -%>
-                </div>
+                <% end -%>
+                <%= boolean_warning if phrase.translations.primary.boolean? -%>
+                
                 <span class="key" title="<%= phrase.key %>"><%= params[:k].present? ?
-                  highlight(h(truncate(phrase.key, :length => 100)), params[:k]) :
-                  h(truncate(phrase.key, :length => 100)) %></span>
+                highlight(h(truncate(phrase.key, :length => 100)), params[:k]) :
+                h(truncate(phrase.key, :length => 100)) %></span>
               </td>
             </tr>
           <% end %>


### PR DESCRIPTION
- Fixed copying original translations on the „updated translations“ page.
- Copying of the original translation is now done via a hidden, disabled textarea in order to preserve line breaks.
- Cleaned up the views a bit.
- Highlighting of interpolations is done by a Ruby helper method (like highlighting of line breaks) instead of JavaScript.
- Line break marker now uses the ¶ symbol, as is common in Rich Text Editors.
- The ¶ symbol is being added using a CSS :before filter. With that Mozilla and Webkit-based browsers do not include the symbol when the user manually selects the text for copying&pasting which is a good thing.
- Refactored the javascripts for interpolations and actions.
