### PR TITLE
Moved dumping functionality into an Export class

### DIFF
--- a/app/models/tolk/locale.rb
+++ b/app/models/tolk/locale.rb
@@ -51,12 +51,9 @@ module Tolk
         all - [primary_locale]
       end
 
-      def dump_all(to = self.locales_config_path)
+      def dump_all(to = nil, exporter = Tolk::Export)
         secondary_locales.each do |locale|
-          File.open("#{to}/#{locale.name}.yml", "w+") do |file|
-            data = locale.to_hash
-            data.respond_to?(:ya2yaml) ? file.write(data.ya2yaml(:syck_compatible => true)) : file.write(YAML.dump(data).force_encoding file.external_encoding.name)
-          end
+          exporter.dump(name: locale.name, data: locale.to_hash, destination: to)
         end
       end
 

--- a/lib/tolk.rb
+++ b/lib/tolk.rb
@@ -4,6 +4,7 @@ require 'tolk/config'
 require 'tolk/engine'
 require 'tolk/sync'
 require 'tolk/import'
+require 'tolk/export'
 
 module Tolk
   # Setup Tolk

--- a/lib/tolk/export.rb
+++ b/lib/tolk/export.rb
@@ -1,0 +1,28 @@
+module Tolk
+  class Export
+    attr_reader :name, :data, :destination
+
+    def initialize(args)
+      @name = args.fetch(:name, '')
+      @data = args.fetch(:data, {})
+      @destination = args.fetch(:destination, self.class.dump_path)
+    end
+
+    def dump
+      File.open("#{destination}/#{name}.yml", "w+") do |file|
+        data.respond_to?(:ya2yaml) ? file.write(data.ya2yaml(:syck_compatible => true)) : file.write(YAML.dump(data).force_encoding file.external_encoding.name)
+      end
+    end
+
+    class << self
+      def dump(args)
+        new(args).dump
+      end
+
+      def dump_path
+        Tolk::Locale._dump_path
+      end
+    end
+
+  end
+end

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -4,7 +4,7 @@ require 'fileutils'
 class ConfigTest < ActiveSupport::TestCase
   test "config default values" do
     assert_equal Proc, Tolk.config.dump_path.class
-    assert_equal "#{Rails.root}/config/locales", Tolk::Locale._dump_path
+    assert_equal "#{Rails.root}/config/locales", Tolk::Export.dump_path
     assert Tolk.config.mapping.keys.include?('ar')
     assert_equal 'Arabic',Tolk.config.mapping['ar']
   end


### PR DESCRIPTION
This commit extracts the dumping functionality in Locale, making it more reusable. This is required for one of my use cases.
