### PR TITLE
Add asset precompile hooks

### DIFF
--- a/lib/tolk/engine.rb
+++ b/lib/tolk/engine.rb
@@ -6,5 +6,11 @@ module Tolk
     SafeYAML::OPTIONS[:deserialize_symbols] = true
 
     isolate_namespace Tolk
+
+    if Rails.version >= '3.1'
+      initializer :assets do |app|
+        app.config.assets.precompile += ['tolk/libraries.js']
+      end
+    end
   end
 end


### PR DESCRIPTION
Add libraries.js to precompile list, this way you don't have to manually add it to your application if you wish to run tolk in production environment.

Even though Tolk is aimed for 3.2, I'm including a test for rails version just to be on the safe side.

Fixes #44
