### PR TITLE
Exclude tokens from gems

### DIFF
--- a/lib/tolk/config.rb
+++ b/lib/tolk/config.rb
@@ -11,7 +11,12 @@ module Tolk
       # Dump locale path by default the locales folder (config/locales)
       attr_accessor :dump_path
 
+      # exclude locales tokens from gems 
+      attr_accessor :exclude_gems_token
+
       def reset
+        @exclude_gems_token = false
+
         @dump_path = Proc.new { "#{Rails.application.root}/config/locales" }
 
         @mapping = {

--- a/lib/tolk/sync.rb
+++ b/lib/tolk/sync.rb
@@ -10,7 +10,14 @@ module Tolk
       end
 
       def load_translations
-        I18n.backend.send :init_translations unless I18n.backend.initialized? # force load
+        if Tolk.config.exclude_gems_token
+          # bypass default init_translations
+          I18n.backend.reload! if I18n.backend.initialized?
+          I18n.backend.instance_variable_set(:@initialized, true)
+          I18n.backend.load_translations(Dir[Rails.root.join('config', 'locales', "*.{rb,yml}")])
+        else
+          I18n.backend.send :init_translations unless I18n.backend.initialized? # force load 
+        end
         translations = flat_hash(I18n.backend.send(:translations)[primary_locale.name.to_sym])
         filter_out_i18n_keys(translations.merge(read_primary_locale_file))
       end


### PR DESCRIPTION
solution for #25 , exclude tokens from gems

> But a real solution would be to import translations only included in the project itself. Since most of those translations will be translated within the gems itself it seems a bit pointless to import them to Tolk. 