### PR TITLE
Fix Relation#count deprecation warning

### DIFF
--- a/app/models/tolk/locale.rb
+++ b/app/models/tolk/locale.rb
@@ -75,7 +75,7 @@ module Tolk
     end
 
     def has_updated_translations?
-      translations.count(:conditions => {:'tolk_translations.primary_updated' => true}) > 0
+      translations.where('tolk_translations.primary_updated' => true).count > 0
     end
 
     def phrases_with_translation(page = nil)


### PR DESCRIPTION
The following warnings appear when testing Tolk with Rails ~>4.0.4:

```
DEPRECATION WARNING: Relation#calculate with finder options is deprecated. Please build a scope and then call calculate on it instead. (called from has_updated_translations? at tolk/app/models/tolk/locale.rb:78)
DEPRECATION WARNING: The :distinct option for `Relation#count` is deprecated. Please use `Relation#distinct` instead. (eg. `relation.distinct.count`). (called from has_updated_translations? at tolk/app/models/tolk/locale.rb:78)
```
