### PR TITLE
Make Tolk able to use either Kaminari or will_paginate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* HEAD
+ * Make Tolk able to use either Kaminari or will_paginate (@lime)
+
 * Tolk 1.7.0
  * Rails 4.2 compatibility (@dnrce)
  * Fixed parameter handling in dump_yaml task (@grk)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ To install add the following to your Gemfile:
   gem 'tolk'
 ```
 
+Also add either [`kaminari`](https://github.com/amatsuda/kaminari) or [`will_paginate`](https://github.com/mislav/will_paginate):
+
+```ruby
+gem 'kaminari'
+# OR
+gem 'will_paginate'
+```
+
 To setup just run:
 
 ```bash

--- a/app/controllers/tolk/application_controller.rb
+++ b/app/controllers/tolk/application_controller.rb
@@ -1,7 +1,10 @@
 require 'tolk/application_controller'
+require 'tolk/pagination'
 
 module Tolk
   class ApplicationController < ActionController::Base
+    include Tolk::Pagination::Methods
+
     helper :all
     protect_from_forgery
 

--- a/app/controllers/tolk/locales_controller.rb
+++ b/app/controllers/tolk/locales_controller.rb
@@ -10,10 +10,10 @@ module Tolk
     def show
       respond_to do |format|
         format.html do
-          @phrases = @locale.phrases_without_translation(params[:page])
+          @phrases = @locale.phrases_without_translation(params[pagination_param])
         end
 
-        format.atom { @phrases = @locale.phrases_without_translation(params[:page], :per_page => 50) }
+        format.atom { @phrases = @locale.phrases_without_translation(params[pagination_param]).per(50) }
 
         format.yaml do
           data = @locale.to_hash
@@ -30,11 +30,11 @@ module Tolk
     end
 
     def all
-      @phrases = @locale.phrases_with_translation(params[:page])
+      @phrases = @locale.phrases_with_translation(params[pagination_param])
     end
 
     def updated
-      @phrases = @locale.phrases_with_updated_translation(params[:page])
+      @phrases = @locale.phrases_with_updated_translation(params[pagination_param])
       render :all
     end
 

--- a/app/controllers/tolk/searches_controller.rb
+++ b/app/controllers/tolk/searches_controller.rb
@@ -3,7 +3,7 @@ module Tolk
     before_filter :find_locale
   
     def show
-      @phrases = @locale.search_phrases(params[:q], params[:scope].to_sym, params[:k], params[:page])
+      @phrases = @locale.search_phrases(params[:q], params[:scope].to_sym, params[:k], params[pagination_param])
     end
 
     private

--- a/app/helpers/tolk/application_helper.rb
+++ b/app/helpers/tolk/application_helper.rb
@@ -1,5 +1,9 @@
+require 'tolk/pagination'
+
 module Tolk
   module ApplicationHelper
+    include Tolk::Pagination::ViewHelper
+
     def format_i18n_value(value)
       value = h(yaml_value(value))
       value = highlight_linebreaks(value)

--- a/app/models/tolk/phrase.rb
+++ b/app/models/tolk/phrase.rb
@@ -4,8 +4,7 @@ module Tolk
 
     validates_uniqueness_of :key
 
-    cattr_accessor :per_page
-    self.per_page = 30
+    paginates_per 30
 
     has_many :translations, :class_name => 'Tolk::Translation', :dependent => :destroy do
       def primary

--- a/app/views/tolk/locales/all.html.erb
+++ b/app/views/tolk/locales/all.html.erb
@@ -58,7 +58,7 @@
       <p><%= locale_form.submit "Save changes", :class => 'save' %></p>
     </div>
     <div class="paginate">
-      <%= will_paginate @phrases %>
+      <%= tolk_paginate @phrases %>
     </div>
   <% end %>
 <% else %>

--- a/app/views/tolk/locales/show.html.erb
+++ b/app/views/tolk/locales/show.html.erb
@@ -54,7 +54,7 @@
       </div>
     <% end %>
     <div class="paginate">
-      <%= will_paginate @phrases %>
+      <%= tolk_paginate @phrases %>
     </div>
   <% else %>
     <p style="text-align: left">There aren't any missing or updated phrases that need translation.</p>

--- a/app/views/tolk/searches/show.html.erb
+++ b/app/views/tolk/searches/show.html.erb
@@ -54,7 +54,7 @@
       </div>
     <% end %>
     <div class="paginate">
-      <%= will_paginate @phrases %>
+      <%= tolk_paginate @phrases %>
     </div>
   <% else %>
     <p style="text-align: left">No search results.</p>

--- a/config/initializers/will_paginate.rb
+++ b/config/initializers/will_paginate.rb
@@ -1,0 +1,18 @@
+if defined?(WillPaginate)
+  ActiveSupport.on_load :active_record do
+    module WillPaginate
+      module ActiveRecord
+        module RelationMethods
+          def per(value = nil) per_page(value) end
+          def total_count() count end
+        end
+      end
+      module CollectionMethods
+        alias_method :num_pages, :total_pages
+      end
+      module PerPage
+        def paginates_per(value) self.per_page=(value) end
+      end
+    end
+  end
+end

--- a/lib/tolk.rb
+++ b/lib/tolk.rb
@@ -1,4 +1,3 @@
-require 'will_paginate'
 require 'safe_yaml/load'
 require 'tolk/config'
 require 'tolk/engine'

--- a/lib/tolk/engine.rb
+++ b/lib/tolk/engine.rb
@@ -7,5 +7,19 @@ module Tolk
     initializer :assets do |app|
       app.config.assets.precompile += ['tolk/libraries.js']
     end
+
+    # We need one of the two pagination engines loaded by this point.
+    # We don't care which one, just one of them will do.
+    begin
+      require 'kaminari'
+    rescue LoadError
+      begin
+        require 'will_paginate'
+      rescue LoadError
+       puts "Please add the kaminari or will_paginate gem to your application's Gemfile."
+       puts "The Tolk engine needs either kaminari or will_paginate in order to paginate."
+       exit
+      end
+    end
   end
 end

--- a/lib/tolk/pagination.rb
+++ b/lib/tolk/pagination.rb
@@ -1,0 +1,28 @@
+module Tolk
+  module Pagination
+    module Methods
+      # Kaminari defaults page_method_name to :page, will_paginate always uses
+      # :page
+      def pagination_method
+        defined?(Kaminari) ? Kaminari.config.page_method_name : :page
+      end
+
+      # Kaminari defaults param_name to :page, will_paginate always uses :page
+      def pagination_param
+        defined?(Kaminari) ? Kaminari.config.param_name : :page
+      end
+    end
+
+    module ViewHelper
+      def tolk_paginate(collection, options = {})
+        if respond_to?(:will_paginate)
+          # If parent app is using Will Paginate, we need to use it also
+          will_paginate collection, options
+        else
+          # Otherwise use Kaminari
+          paginate collection, options
+        end
+      end
+    end
+  end
+end

--- a/test/unit/locale_test.rb
+++ b/test/unit/locale_test.rb
@@ -38,7 +38,7 @@ class LocaleTest < ActiveSupport::TestCase
   end
 
   test "paginating phrases without translations" do
-    Tolk::Phrase.per_page = 2
+    Tolk::Phrase.paginates_per(2)
     locale = tolk_locales(:se)
 
     page1 = locale.phrases_without_translation
@@ -55,7 +55,7 @@ class LocaleTest < ActiveSupport::TestCase
   end
 
   test "paginating phrases with translations" do
-    Tolk::Phrase.per_page = 5
+    Tolk::Phrase.paginates_per(5)
     locale = tolk_locales(:en)
 
     page1 = locale.phrases_with_translation

--- a/tolk.gemspec
+++ b/tolk.gemspec
@@ -20,13 +20,13 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.3'
 
   s.add_runtime_dependency 'rails', '>= 4.0', '< 4.3'
-  s.add_runtime_dependency 'will_paginate'
   s.add_runtime_dependency 'safe_yaml', ">= 0.8.6"
 
   s.add_development_dependency 'capybara', '~> 2.4.4'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'mocha', '>= 1.0'
   s.add_development_dependency 'selenium-webdriver'
+  s.add_development_dependency 'will_paginate'
 
 
   if File.exists?('UPGRADING')


### PR DESCRIPTION
This should fix #62.

Heavily based on the way the pagination issue is handled in [radar/forem](https://github.com/radar/forem), this PR removes `will_paginate` from our dependencies, and lets the user decide whether to use `will_paginate` or `kaminari`.

What do you think?