### PR TITLE
fixes require statements to match sprockets style

### DIFF
--- a/app/assets/stylesheets/tolk/application.css
+++ b/app/assets/stylesheets/tolk/application.css
@@ -1,2 +1,4 @@
-# =require 'tolk/reset.css'
-# =require 'tolk/screen.css'
+/*
+* =require 'tolk/reset.css'
+* =require 'tolk/screen.css'
+*/


### PR DESCRIPTION
I have faced a problem while trying to process tolk assets by ```rake assets:precompile```. This minor change to sprockets-required style solves the issue.