### PR TITLE
Include initializers in gem files

### DIFF
--- a/tolk.gemspec
+++ b/tolk.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
     s.post_install_message = File.read("UPGRADING")
   end
 
-  s.files = Dir['README', 'MIT-LICENSE', 'config/routes.rb', 'init.rb', 'lib/**/*', 'app/**/*', 'public/tolk/**/*']
+  s.files = Dir['README', 'MIT-LICENSE', 'config/**/*', 'init.rb', 'lib/**/*', 'app/**/*', 'public/tolk/**/*']
 
   s.require_path = 'lib'
 end


### PR DESCRIPTION
Our `gemspec` is pretty specific about what files to include in the built gem, causing the `will_paginate` initializer to be left out, in turn breaking compatibility with `will_paginate`.

Fixes #108.