### PR TITLE
Pagination constant (before load_missing_constant is called).

### DIFF
--- a/app/controllers/tolk/application_controller.rb
+++ b/app/controllers/tolk/application_controller.rb
@@ -1,6 +1,3 @@
-require 'tolk/application_controller'
-require 'tolk/pagination'
-
 module Tolk
   class ApplicationController < ActionController::Base
     include Tolk::Pagination::Methods

--- a/app/helpers/tolk/application_helper.rb
+++ b/app/helpers/tolk/application_helper.rb
@@ -1,5 +1,3 @@
-require 'tolk/pagination'
-
 module Tolk
   module ApplicationHelper
     include Tolk::Pagination::ViewHelper

--- a/lib/tolk.rb
+++ b/lib/tolk.rb
@@ -5,6 +5,7 @@ require 'tolk/sync'
 require 'tolk/import'
 require 'tolk/export'
 require 'tolk/yaml'
+require 'tolk/pagination'
 
 module Tolk
   # Setup Tolk


### PR DESCRIPTION
I ran into #107 a few more times. To reproduce the issue mentioned in #107:

1. Have

```ruby
  Tolk::ApplicationController.authenticator = proc {
    raise Error
  }
```

2. start `rails server`

3. Go to '/translate'

which results in a call to ActiveSupport's `load_missing_constant` with `from_mod=Tolk` and `const_name=:Pagination`. The problem is, at this point the :Pagination constant is missing from Tolk module. Moving `require`  to tolk.rb solved the problem for me. All tests are still passing on my machine.