### PR TITLE
CI: Update bundler before installing gems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: ruby
 
+before_install:
+  - gem update bundler
+
 before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"


### PR DESCRIPTION
Some versions of bundler are affected by a bug that causes them to throw

    NoMethodError: undefined method `spec' for nil:NilClass

during installation of the tolk gem. This bug was fixed in bundler@a0c90cd, but several of
Travis's Ruby environments are based on older affected versions. To resolve, we force an update.