### PR TITLE
Updating migration and migration template for Rails 5.1

### DIFF
--- a/db/migrate/20110824135256_migrate_tolk.rb
+++ b/db/migrate/20110824135256_migrate_tolk.rb
@@ -1,4 +1,4 @@
-class MigrateTolk < ActiveRecord::Migration
+class MigrateTolk < ActiveRecord::Migration[4.2]
   def self.up
     create_table "tolk_locales", :force => true do |t|
       t.string   "name"

--- a/lib/generators/tolk/templates/migration.rb
+++ b/lib/generators/tolk/templates/migration.rb
@@ -1,4 +1,4 @@
-class CreateTolkTables < ActiveRecord::Migration
+class CreateTolkTables < ActiveRecord::Migration[4.2]
   def self.up
     create_table :tolk_locales do |t|
       t.string   :name


### PR DESCRIPTION
While executing `rake tolk:setup` in a rails 5.1.4 project I got the following error message:

> StandardError: Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for:
>
> class CreateTolkTables < ActiveRecord::Migration[4.2]

Therefore I adjusted the migration version to the suggested rails version.