### PR TITLE
Necessary change to enable YAML export of a locale in Rails 5.1

### DIFF
--- a/app/controllers/tolk/locales_controller.rb
+++ b/app/controllers/tolk/locales_controller.rb
@@ -17,7 +17,7 @@ module Tolk
 
         format.yaml do
           data = @locale.to_hash
-          render :text => Tolk::YAML.dump(data)
+          render :plain => Tolk::YAML.dump(data)
         end
 
       end


### PR DESCRIPTION
`render :text` won't render in Rails 5.1 since `render :text` was removed with the release of Rails 5.1 ([Rails 5.1 CHANGELOG](https://github.com/rails/rails/blob/v5.1.0/actionpack/CHANGELOG.md))

```Started GET "/tolk/locales/en.yml" for 127.0.0.1 at 2017-11-23 13:28:11 +0100
Processing by Tolk::LocalesController#show as YAML
  Parameters: {"id"=>"en"}

[...]
  
ActionView::MissingTemplate (Missing template tolk/locales/show, tolk/application/show with {:locale=>[:de], :formats=>[:yaml], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby, :coffee, :jbuilder]}. Searched in:
  * "/Users/sgrosse/code/persondb_translations/rails_app/app/views"
  * "/Users/sgrosse/.rvm/gems/ruby-2.4.1/gems/tolk-3.0.0/app/views"
):
```

Therefore it must be changed to render :plain.

```Started GET "/tolk/locales/en.yml" for 127.0.0.1 at 2017-11-23 13:30:38 +0100
   (0.5ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
Processing by Tolk::LocalesController#show as YAML
  Parameters: {"id"=>"en"}

[...]

  Rendering text template
  Rendered text template (0.0ms)
Completed 200 OK in 347ms (Views: 2.6ms | ActiveRecord: 45.5ms)
```