### PR TITLE
Allow dumping yaml without adding linebreaks

### DIFF
--- a/lib/tolk/config.rb
+++ b/lib/tolk/config.rb
@@ -23,6 +23,9 @@ module Tolk
       # strip translation texts automatically
       attr_accessor :strip_texts
 
+      # specify line width which Yaml.dump will use to break lines. -1 for not breaking
+      attr_accessor :yaml_line_width
+
       def reset
         @exclude_gems_token = false
 
@@ -78,6 +81,8 @@ module Tolk
           'zh-CN' => 'Chinese (Simplified)',
           'zh-TW' => 'Chinese (Traditional)'
         }
+
+        @yaml_line_width = Psych::Handler::OPTIONS.line_width # Psych::Handler::DumperOptions uses 0 as "default" for unset
       end
     end
 

--- a/lib/tolk/yaml.rb
+++ b/lib/tolk/yaml.rb
@@ -22,7 +22,7 @@ module Tolk
       if payload.respond_to?(:ya2yaml)
         payload.ya2yaml(:syck_compatible => true)
       else
-        ::YAML.dump(payload)
+        ::YAML.dump(payload, line_width: Tolk::Config.yaml_line_width)
       end
     end
   end


### PR DESCRIPTION
Psych breaks long strings by default at around 80 character. This change
makes this behaviour configurable. It also retains default behaviour as
it was before the change.