### PR TITLE
Add `Tolk.config.base_controller`

### DIFF
--- a/app/controllers/tolk/application_controller.rb
+++ b/app/controllers/tolk/application_controller.rb
@@ -1,5 +1,5 @@
 module Tolk
-  class ApplicationController < ActionController::Base
+  class ApplicationController < Tolk.config.base_controller.constantize
     include Tolk::Pagination::Methods
 
     helper :all

--- a/lib/generators/tolk/templates/initializer.erb
+++ b/lib/generators/tolk/templates/initializer.erb
@@ -409,4 +409,5 @@ Tolk.config do |config|
   # config.mapping['zu']      = 'Zulu'
   # config.mapping['zu-ZA']   = 'Zulu (South Africa)
 
+  # config.base_controller = 'ApplicationController'
 end

--- a/lib/tolk/config.rb
+++ b/lib/tolk/config.rb
@@ -26,6 +26,10 @@ module Tolk
       # specify line width which Yaml.dump will use to break lines. -1 for not breaking
       attr_accessor :yaml_line_width
 
+      # specify controller to inherit from to keep Tolk controllers
+      # in the same context than the rest of your app
+      attr_accessor :base_controller
+
       def reset
         @exclude_gems_token = false
 
@@ -83,6 +87,8 @@ module Tolk
         }
 
         @yaml_line_width = Psych::Handler::OPTIONS.line_width # Psych::Handler::DumperOptions uses 0 as "default" for unset
+
+        @base_controller =  'ActionController::Base'
       end
     end
 

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -8,5 +8,6 @@ class ConfigTest < ActiveSupport::TestCase
     assert Tolk.config.mapping.keys.include?('ar')
     assert_equal 'Arabic',Tolk.config.mapping['ar']
     assert_equal true, Tolk.config.strip_texts
+    assert_equal 'ActionController::Base', Tolk.config.base_controller
   end
 end


### PR DESCRIPTION
It allows to specify controller to inherit from to keep Tolk
controllers in the same context than the rest of your app.

Example: `config/initializers/tolk.rb`

```ruby
Tolk.config do |config|
  config.base_controller = 'ApplicationController'
end
```