### PR TITLE
Improve sync and import performance

### DIFF
--- a/lib/tolk/import.rb
+++ b/lib/tolk/import.rb
@@ -24,27 +24,27 @@ module Tolk
         data = locale.read_locale_file
         return unless data
 
-        phrases = Tolk::Phrase.all
+        phrases_by_key = Tolk::Phrase.all.index_by(&:key)
+        translated_phrase_ids = Set.new(locale.translations.pluck(:phrase_id))
         count = 0
 
         data.each do |key, value|
-          phrase = phrases.detect {|p| p.key == key}
-
-          if phrase
-            translation = locale.translations.new(:text => value, :phrase => phrase)
-            if translation.save
-              count = count + 1
-            elsif translation.errors[:variables].present?
-              puts "[WARN] Key '#{key}' from '#{locale_name}.yml' could not be saved: #{translation.errors[:variables].first}"
-            end
-          else
+          phrase = phrases_by_key[key]
+          unless phrase
             puts "[ERROR] Key '#{key}' was found in '#{locale_name}.yml' but #{Tolk::Locale.primary_language_name} translation is missing"
+            next
+          end
+          next if translated_phrase_ids.include?(phrase.id)
+          translation = locale.translations.new(:text => value, :phrase => phrase)
+          if translation.save
+            count = count + 1
+          elsif translation.errors[:variables].present?
+            puts "[WARN] Key '#{key}' from '#{locale_name}.yml' could not be saved: #{translation.errors[:variables].first}"
           end
         end
 
         puts "[INFO] Imported #{count} keys from #{locale_name}.yml"
       end
-
     end
 
     def read_locale_file

--- a/lib/tolk/sync.rb
+++ b/lib/tolk/sync.rb
@@ -62,24 +62,26 @@ module Tolk
         primary_locale = self.primary_locale
 
         # Handle deleted phrases
-        translations.present? ? Tolk::Phrase.where(["tolk_phrases.key NOT IN (?)", translations.keys]).destroy_all : Tolk::Phrase.destroy_all
+        Tolk::Phrase.where.not(:key => translations.keys).destroy_all
 
-        phrases = Tolk::Phrase.all
+        phrases_by_key = Tolk::Phrase.all.index_by(&:key)
+        primary_translation_by_phrase_id = primary_locale.translations.index_by(&:phrase_id)
 
         translations.each do |key, value|
           next if value.is_a?(Proc)
           # Create phrase and primary translation if missing
-          existing_phrase = phrases.detect {|p| p.key == key} || Tolk::Phrase.create!(:key => key)
-          translation = existing_phrase.translations.primary || primary_locale.translations.build(:phrase_id => existing_phrase.id)
+          phrase = phrases_by_key[key] || Tolk::Phrase.create!(:key => key)
+          translation = primary_translation_by_phrase_id[phrase.id]
+          translation ||= primary_locale.translations.build(:phrase => phrase)
           translation.text = value
 
           if translation.changed? && !translation.new_record?
             # Set the primary updated flag if the primary translation has changed and it is not a new record.
-            existing_phrase.translations.where(Tolk::Translation.arel_table[:locale_id].not_eq(primary_locale.id)).update_all({ :primary_updated => true })
+            phrase.translations.where.not(:locale_id => primary_locale.id).update_all({ :primary_updated => true })
           end
 
           translation.primary = true
-          translation.save!
+          translation.save! if translation.changed?
         end
       end
 


### PR DESCRIPTION
Hi!

It started with changing `detect {}` to `Hash#[]` to improve complexity from O(n^2) to O(n), but then I've found n+1 queries issues and unnecessary empty transactions. Eliminating this ones brought even more performance improvement.

Here are benchmarks with 6k phrases:

```
# MASTER
sync cold
149.883918  14.210877 164.094795 (265.270893)
sync no changes
100.717126   7.522332 108.239458 (151.659595)
sync with changes
103.904508   7.694762 111.599270 (160.080612)

import_locale cold
 69.762962   4.765952  74.528914 (110.758120)
import_locale no changes
 64.888690   2.745937  67.634627 ( 95.774893)
import_locale with changes
 82.601388   4.718448  87.319836 (100.892517)

# PATCHED
sync cold
133.512154  12.764821 146.276975 (236.263289)
sync no changes
  6.607716   0.231217   6.838933 (  7.227873)
sync with changes
  7.703475   0.321519   8.024994 (  8.687044)

import_locale cold
  58.703036   4.923959  63.626995 ( 97.022634)
import_locale no changes
  3.026084   0.187832   3.213916 (  3.657752)
import_locale with changes
  1.029647   0.027418   1.057065 (  1.181402)
```