### PR TITLE
Add ignore keys option

### DIFF
--- a/lib/tolk/config.rb
+++ b/lib/tolk/config.rb
@@ -30,6 +30,9 @@ module Tolk
       # in the same context than the rest of your app
       attr_accessor :base_controller
 
+      # Ignore specific keys
+      attr_accessor :ignore_keys
+
       def reset
         @exclude_gems_token = false
 
@@ -89,6 +92,8 @@ module Tolk
         @yaml_line_width = Psych::Handler::OPTIONS.line_width # Psych::Handler::DumperOptions uses 0 as "default" for unset
 
         @base_controller =  'ActionController::Base'
+
+        @ignore_keys = []
       end
     end
 

--- a/lib/tolk/sync.rb
+++ b/lib/tolk/sync.rb
@@ -30,7 +30,8 @@ module Tolk
           I18n.backend.send :init_translations unless I18n.backend.initialized? # force load
         end
         translations = flat_hash(I18n.backend.send(:translations)[primary_locale.name.to_sym])
-        filter_out_i18n_keys(translations.merge(read_primary_locale_file))
+        filtered = filter_out_i18n_keys(translations.merge(read_primary_locale_file))
+        filter_out_ignored_keys(filtered)
       end
 
       def read_primary_locale_file
@@ -85,6 +86,18 @@ module Tolk
 
       def filter_out_i18n_keys(flat_hash)
         flat_hash.reject { |key, value| key.starts_with? "i18n" }
+      end
+
+      def filter_out_ignored_keys(flat_hash)
+        ignored = Tolk.config.ignore_keys
+
+        return flat_hash unless ignored.any?
+
+        ignored_escaped = ignored.map { |key| Regexp.escape(key) }
+
+        regexp = Regexp.new(/\A#{ignored_escaped.join('|')}/)
+
+        flat_hash.reject { |key, _| regexp.match?(key) }
       end
     end
   end

--- a/test/locales/sync/en.yml
+++ b/test/locales/sync/en.yml
@@ -1,7 +1,9 @@
---- 
-en: 
-  nested: 
+---
+en:
+  nested:
     hello_country: Nested Hello Country
+    ignored: This should be ignored
   hello_world: Hello World
   i18n:
     plural: Locale specific pluralization rules
+  ignored: This should be ignored

--- a/test/unit/sync_test.rb
+++ b/test/unit/sync_test.rb
@@ -224,4 +224,16 @@ class SyncTest < ActiveSupport::TestCase
   ensure
     FileUtils.rm_f(tmpdir)
   end
+
+  def test_sync_ignore_keys
+    Tolk.config.ignore_keys = %w[ignored nested.ignored]
+
+    Tolk::Locale.sync!
+
+    phrase = Tolk::Phrase.all.detect {|p| p.key == 'ignored'}
+    assert_nil phrase
+
+    phrase = Tolk::Phrase.all.detect {|p| p.key == 'nested.ignored'}
+    assert_nil phrase
+  end
 end


### PR DESCRIPTION
Add an option to be able to ignore specific keys when running `rake tolk:sync`.

Example:

```
Tolk.config do |config|
  config.ignore_keys = %w[faker app.errors]
end
```

This will ignore all `faker.*` keys and all `app.errors.*` (but not `app.warnings`, for example)
