### PR TITLE
Fixes small pluck typo in Tolk::Locale

### DIFF
--- a/app/models/tolk/locale.rb
+++ b/app/models/tolk/locale.rb
@@ -92,7 +92,7 @@ module Tolk
     end
 
     def count_phrases_without_translation
-      existing_ids = self.translations.pluck(&:phrase_id).uniq
+      existing_ids = self.translations.pluck(:phrase_id).uniq
       Tolk::Phrase.count - existing_ids.count
     end
 


### PR DESCRIPTION
Small typo with great performance impact because of objects allocations.

```existing_ids = self.translations.pluck(&:phrase_id).uniq```
Typo loads all the translations from DB into collection and then calls uniq on it.
Of course count from the next line works just fine on both array of ids and collection 😃 