### PR TITLE
Update font definitions fallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 * Tolk 3.2.1
-  * Move Lucida Sans Unicode as initial font choice and remove non-unicode version (@marcindrozd)
+  * Update fonts used to unicode supporting ones and remove non-unicode version (@marcindrozd)
 
 * Tolk 3.2.0
   * Faster sync ! (@printercu)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* Tolk 3.2.1
+  * Move Lucida Sans Unicode as initial font choice and remove non-unicode version (@marcindrozd)
+
 * Tolk 3.2.0
   * Faster sync ! (@printercu)
   * Allow to ignore keys (@rikas)

--- a/app/assets/stylesheets/tolk/screen.scss
+++ b/app/assets/stylesheets/tolk/screen.scss
@@ -17,7 +17,7 @@ a:hover {color: #000;}
  * Variables
 **/
 $primary_color: #2fadcf;
-$font_family: "Lucida Sans Unicode", "Lucida Grande", sans-serif;
+$font_family: Tahoma, "Lucida Sans Unicode", "Lucida Grande", sans-serif;
 
 /**
  * Some generic components

--- a/app/assets/stylesheets/tolk/screen.scss
+++ b/app/assets/stylesheets/tolk/screen.scss
@@ -17,7 +17,7 @@ a:hover {color: #000;}
  * Variables
 **/
 $primary_color: #2fadcf;
-$font_family: Tahoma, "Lucida Sans Unicode", "Lucida Grande", sans-serif;
+$font_family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
 
 /**
  * Some generic components

--- a/app/assets/stylesheets/tolk/screen.scss
+++ b/app/assets/stylesheets/tolk/screen.scss
@@ -17,7 +17,7 @@ a:hover {color: #000;}
  * Variables
 **/
 $primary_color: #2fadcf;
-$font_family: "Lucida Sans", "Lucida Grande", "Lucida Sans Unicode", sans-serif;
+$font_family: "Lucida Sans Unicode", "Lucida Grande", sans-serif;
 
 /**
  * Some generic components

--- a/lib/tolk/version.rb
+++ b/lib/tolk/version.rb
@@ -1,3 +1,3 @@
 module Tolk
-  VERSION = "3.2.0"
+  VERSION = "3.2.1"
 end


### PR DESCRIPTION
During our work with tolk engine, we found that the fonts are not displayed properly in Vietnamese language.

Current font definitions in css put `Lucida Sans` as the initial version and `Lucida Sans Unicode` as fallback. I believe that it would be more useful to have `Lucida Sans Unicode` as initial selection since it should contain all unicode characters and only have `Lucida Grande` as fallback for Mac OS. `Lucida Sans` since it does not support unicode is probably not needed.

We could probably also swap or add additional web-safe fallbacks for Linux systems. According to the https://en.wikipedia.org/wiki/Lucida_Sans_Unicode article, Lucida Sans Unicode and Lucida Grande should cover Windows (The font comes pre-installed with all Microsoft Windows versions since Windows 98) and Mac (A nearly identical font, called Lucida Grande, ships as the default system font with Apple's Mac OS X operating system).

The only thing that is not clear to me is if Lucida Sans Unicode on Windows covers all languages. I could not find a source to confirm this fully. Other safe fallbacks or fonts that we could offer would maybe be `Tahoma` or `Arial`?

I am happy to discuss.