### PR TITLE
Fix numeric values being dumped as strings

### DIFF
--- a/app/models/tolk/locale.rb
+++ b/app/models/tolk/locale.rb
@@ -153,14 +153,14 @@ module Tolk
     end
 
     def to_hash
-      data = translations.joins(:phrase).order("tolk_phrases.key ASC").pluck("tolk_phrases.key, text").
-      each_with_object(Hash.new(0)) do |translation, locale|
-        if translation[0].include?(".")
-          locale.deep_merge!(unsquish(translation[0], translation[1]))
-        else
-          locale[translation[0]] = translation[1]
+      data = translations.includes(:phrase).references(:phrases).order(phrases.arel_table[:key]).
+        each_with_object({}) do |translation, locale|
+          if translation.phrase.key.include?(".")
+            locale.deep_merge!(unsquish(translation.phrase.key, translation.value))
+          else
+            locale[translation.phrase.key] = translation.value
+          end
         end
-      end
       { name => data }
     end
 

--- a/test/unit/locale_test.rb
+++ b/test/unit/locale_test.rb
@@ -22,7 +22,7 @@ class LocaleTest < ActiveSupport::TestCase
         },
         "human" => {
           "format" => {
-            "precision" => "1"
+            "precision" => 1
           }
         }
       }


### PR DESCRIPTION
After 5231544e829aa61fb316eaad0677d8274a9609ec, numeric values started to be dumped as strings.

This can cause some problems. One example is "number.currency.precision" in Rails. When defined as an string, it will raise an exception: https://stackoverflow.com/a/32417826

5231544e829aa61fb316eaad0677d8274a9609ec broke a test that checks for this specifically but it was "fixed" in c58f9188e52227d3207842bba9f1ae10812a84cb.

So I also did a partial reversion of c58f9188e52227d3207842bba9f1ae10812a84cb.