### PR TITLE
Fixes tolk sync ignore regexp

### DIFF
--- a/lib/tolk/sync.rb
+++ b/lib/tolk/sync.rb
@@ -97,7 +97,7 @@ module Tolk
 
         ignored_escaped = ignored.map { |key| Regexp.escape(key) }
 
-        regexp = Regexp.new(/\A#{ignored_escaped.join('|')}/)
+        regexp = Regexp.new(/\A(#{ignored_escaped.join('|')})\Z/)
 
         flat_hash.reject { |key, _| regexp === key }
       end

--- a/test/locales/sync/en.yml
+++ b/test/locales/sync/en.yml
@@ -7,3 +7,4 @@ en:
   i18n:
     plural: Locale specific pluralization rules
   ignored: This should be ignored
+  includesignored: This should not be ignored

--- a/test/unit/sync_test.rb
+++ b/test/unit/sync_test.rb
@@ -226,7 +226,7 @@ class SyncTest < ActiveSupport::TestCase
   end
 
   def test_sync_ignore_keys
-    Tolk.config.ignore_keys = %w[ignored nested.ignored]
+    Tolk.config.ignore_keys = %w[anytingbefore ignored nested.ignored]
 
     Tolk::Locale.sync!
 
@@ -235,5 +235,8 @@ class SyncTest < ActiveSupport::TestCase
 
     phrase = Tolk::Phrase.all.detect {|p| p.key == 'nested.ignored'}
     assert_nil phrase
+
+    phrase = Tolk::Phrase.all.detect {|p| p.key == 'includesignored'}
+    assert_equal 'includesignored', phrase.key
   end
 end


### PR DESCRIPTION
Copied content from https://github.com/tolk/tolk/issues/156

version 3.2.1

The docs say:
```

config.ignore_keys = ['faker', 'devise']
# Ignore all faker.* and devise.* keys

```
**Current steup**

You can reproduce it with this test steup:

test/unit/sync_test.rb

```
  def test_sync_ignore_keys
    Tolk.config.ignore_keys = %w[anything_at_first_place_is_important ignored nested.ignored ]

    Tolk::Locale.sync!

    phrase = Tolk::Phrase.all.detect {|p| p.key == 'ignored'}
    assert_nil phrase

    phrase = Tolk::Phrase.all.detect {|p| p.key == 'nested.ignored'}
    assert_nil phrase

    phrase = Tolk::Phrase.all.detect {|p| p.key == 'includesignored'}
    assert_equal 'includesignored', phrase.key
  end
```

test/locales/sync/en.yml

```
---
en:
  nested:
    hello_country: Nested Hello Country
    ignored: This should be ignored
  hello_world: Hello World
  i18n:
    plural: Locale specific pluralization rules
  ignored: This should be ignored
  includesignored: This should not be ignored
```

```
~/.../forks/tolk >>> bin/rails test test/unit/sync_test.rb                                                                                                                        ±[●●][master]
Run options: --seed 32283

# Running:

...........F

Failure:
SyncTest#test_sync_ignore_keys [/home/patrick/projects/gems/tolk/test/unit/sync_test.rb:240]:
Expected: "includesignored"
  Actual: nil
```

**Solution 1**

make sure that the regexp in sync.rb actually builds the "correct" regexp.

e.g `regexp = Regexp.new(/\A(#{ignored_escaped.join('|')})\Z/)`

**Solution 2**

Change the docs because what i encounter is the expected behaviour.