### PR TITLE
Improves the ingored_keys regexp

### DIFF
--- a/lib/tolk/sync.rb
+++ b/lib/tolk/sync.rb
@@ -97,7 +97,7 @@ module Tolk
 
         ignored_escaped = ignored.map { |key| Regexp.escape(key) }
 
-        regexp = Regexp.new(/\A(#{ignored_escaped.join('|')})\Z/)
+        regexp = Regexp.new(/\A(#{ignored_escaped.join('|')})/)
 
         flat_hash.reject { |key, _| regexp === key }
       end

--- a/lib/tolk/sync.rb
+++ b/lib/tolk/sync.rb
@@ -97,7 +97,7 @@ module Tolk
 
         ignored_escaped = ignored.map { |key| Regexp.escape(key) }
 
-        regexp = Regexp.new(/\A(#{ignored_escaped.join('|')})/)
+        regexp = Regexp.new(/\A(#{ignored_escaped.join('|')})(:?\.|\Z)/)
 
         flat_hash.reject { |key, _| regexp === key }
       end

--- a/test/locales/sync/en.yml
+++ b/test/locales/sync/en.yml
@@ -7,4 +7,6 @@ en:
   i18n:
     plural: Locale specific pluralization rules
   ignored: This should be ignored
-  includesignored: This should not be ignored
+  ignorednested:
+    nested: This should be ignored
+  notignored: This should not be ignored

--- a/test/locales/sync/en.yml
+++ b/test/locales/sync/en.yml
@@ -9,4 +9,4 @@ en:
   ignored: This should be ignored
   ignorednested:
     nested: This should be ignored
-  notignored: This should not be ignored
+  not_ignored: This should not be ignored

--- a/test/unit/sync_test.rb
+++ b/test/unit/sync_test.rb
@@ -226,7 +226,7 @@ class SyncTest < ActiveSupport::TestCase
   end
 
   def test_sync_ignore_keys
-    Tolk.config.ignore_keys = %w[anytingbefore ignored nested.ignored]
+    Tolk.config.ignore_keys = %w[anythingbefore ignored nested.ignored ignorednested]
 
     Tolk::Locale.sync!
 
@@ -236,7 +236,10 @@ class SyncTest < ActiveSupport::TestCase
     phrase = Tolk::Phrase.all.detect {|p| p.key == 'nested.ignored'}
     assert_nil phrase
 
-    phrase = Tolk::Phrase.all.detect {|p| p.key == 'includesignored'}
-    assert_equal 'includesignored', phrase.key
+    phrase = Tolk::Phrase.all.detect {|p| p.key == 'ignorednested.ignored'}
+    assert_nil phrase
+
+    phrase = Tolk::Phrase.all.detect {|p| p.key == 'notignored'}
+    assert_equal 'notignored', phrase.key
   end
 end

--- a/test/unit/sync_test.rb
+++ b/test/unit/sync_test.rb
@@ -239,7 +239,7 @@ class SyncTest < ActiveSupport::TestCase
     phrase = Tolk::Phrase.all.detect {|p| p.key == 'ignorednested.ignored'}
     assert_nil phrase
 
-    phrase = Tolk::Phrase.all.detect {|p| p.key == 'notignored'}
-    assert_equal 'notignored', phrase.key
+    phrase = Tolk::Phrase.all.detect {|p| p.key == 'not_ignored'}
+    assert_equal 'not_ignored', phrase.key
   end
 end


### PR DESCRIPTION
As discussed in #158 the ignored_keys regexp did not work as documented and expected.

The regexp is no matching in the following way:

ignored_key = foo

```
foo: ignored
foo: // everything under foo. will be ignored
  bar: 
  baz:
foobar: will not be ignored
bar:
  foo: will not be ignored
```

closes #158 