### PR TITLE
🐛 Fix compatibility with Rails 7

### DIFF
--- a/app/models/tolk/translation.rb
+++ b/app/models/tolk/translation.rb
@@ -4,8 +4,8 @@ module Tolk
 
     scope :containing_text, lambda {|query| where("tolk_translations.text LIKE ?", "%#{query}%") }
 
-    serialize :text
-    serialize :previous_text
+    serialize :text, coder: YAML
+    serialize :previous_text, coder: YAML
     validate :validate_text_not_nil, :if => proc {|r| r.primary.blank? && !r.explicit_nil && !r.boolean?}
     validate :check_matching_variables, :if => proc { |tr| tr.primary_translation.present? }
 

--- a/lib/generators/tolk/templates/initializer.erb
+++ b/lib/generators/tolk/templates/initializer.erb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Tolk config file. Generated on <%= DateTime.now.to_s(:long) %>
+# Tolk config file. Generated on <%= DateTime.now.strftime("%B %d, %Y %H:%M:%S") %>
 # See github.com/tolk/tolk for more informations
 
 Tolk.config do |config|

--- a/lib/generators/tolk/utils.rb
+++ b/lib/generators/tolk/utils.rb
@@ -20,12 +20,20 @@ module Tolk
 
       module ClassMethods
         def next_migration_number(dirname)
-          if ActiveRecord::Base.timestamped_migrations
+          if timestamped_migrations?
             migration_number = Time.now.utc.strftime("%Y%m%d%H%M%S").to_i
             migration_number += 1
             migration_number.to_s
           else
             "%.3d" % (current_migration_number(dirname) + 1)
+          end
+        end
+
+        def timestamped_migrations?
+          if Rails::VERSION::MAJOR >= 7
+            ActiveRecord.timestamped_migrations
+          else
+            ActiveRecord::Base.timestamped_migrations
           end
         end
       end


### PR DESCRIPTION
This gem is currently not compatible with Rails 7 due to the following error:

```
undefined method `timestamped_migrations' for class ActiveRecord::Base
```

The Sorcery gem had the same issue, and solved it in a similar way: https://github.com/Sorcery/sorcery/pull/352